### PR TITLE
github: don't mark as a draft

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,11 +18,22 @@ jobs:
           make local-all
           echo ${{ github.sha }} > Release.txt
 
-      - name: Create a Draft Release
-        uses: softprops/action-gh-release@v2
+      - name: Create Draft Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          draft: true
-          name: working-draft
-          files: |
-            Release.txt
-            virtio-v1.4-wd01.pdf
+          tag_name: virio-msg-draft-v${{ github.run_number }} # Or a more meaningful tag
+          release_name: Draft ${{ github.run_number }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: virtio-v1.4-wd01.pdf
+          asset_name: virtio-v1.4-wd01.pdf
+          asset_content_type: application/pdf

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Tools
         run: |
+          sudo apt update
           sudo apt install texlive-full
 
       - name: Build Docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
Having a draft means that the final asset won't be visible outside the
project which is what we want. Use prerelease instead.
