### PR TITLE
Introduce a protocol version and a message for it

### DIFF
--- a/transport-msg.tex
+++ b/transport-msg.tex
@@ -15,8 +15,9 @@ cross system communications required in an heterogeneous system configuration.
 
 The messages have the following properties:
 \begin{itemize}
-\item A message has a minimum size of 8 bytes and any implementation must support
-  to transmit messages of up to 64 bytes.
+\item A message has a minimum size of 8 bytes (header size with an empty payload)
+  and any implementation must support to transmit messages of up to 44 bytes
+  (size of the set virtqueue message).
 \item Most messages are driver/device initialization messages.
 \item Messages are expected to be sent at low frequencies and quick round-trip is
   not necessary and should not impact global performances (as communication
@@ -35,7 +36,7 @@ VIRTIO_MSG_ID & 1 & 1 & Message ID \\
 \hline
 VIRTIO_MSG_DEV_ID & 2 & 2 & Device ID, must be set to 0 if VIRTIO_MSG_TYPE Bit[1]=1\\
 \hline
-VIRTIO_MSG_SIZE & 4 & 2 & Message Payload Size\\
+VIRTIO_MSG_SIZE & 4 & 2 & Message Size (including header)\\
 \hline
 VIRTIO_MSG_PAYLOAD & 6 & ...  & Payload \\
 \hline
@@ -198,6 +199,13 @@ The version negociation shall be done by the driver following those steps:
         negociate a different version.
 \end{itemize}
 
+During the negociation, the driver informs the device of the maximum message
+size it can receive and the device informs back the driver of the maximum
+message it can receive. Each side must save this information and ensure not
+to send messages bigger than what the other side can handle. It is generally
+expected that both side will not send message bigger than the biggest size
+supported by both sides.
+
 \begin{tabular}{|l|l|l|l|}
 \hline
 Type & Offset & Size (bytes) & Content \\
@@ -233,10 +241,10 @@ Answer & 0 & 4 & Device ID \\
 
 \msgdef{GET_FEATURES}
 
-The get features message is used to retrieve a number of bits of feature
-information from the device. The driver requests features at an index (in bits)
-and a number of bits and the device answers with the features bits at the
-wanted index.
+The get features message is used to retrieve a number of blocks of 32 bits of
+feature information from the device. The driver requests features at a block
+index (one block is 32bits of feature) and a number of blocks and the device
+answers with the features bits for the requested blocks.
 
 The maximum number of feature bits that can be requested in one message depends
 on the maximum message size supported by both sides.
@@ -246,8 +254,7 @@ features available after the index, the backend must return an all-zero
 response.
 
 If there are no features available at and after the requested index, the
-backend must return an ERROR message to inform the frontend that it does not
-need to scan features further.
+backend must return an ERROR message.
 
 This message is sent by the driver to the device and expects an answer from the
 device.
@@ -256,11 +263,11 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 4 & Feature bit index \\
-& 4 & 4 & Number of features \\
+Request & 0 & 4 & Feature block index \\
+& 4 & 4 & Number of feature blocks \\
 \hline
-Answer & 0 & 4 & Feature bit index \\
-& 4 & 4 & Number of features \\
+Answer & 0 & 4 & Feature block index \\
+& 4 & 4 & Number of feature blocks \\
 & 8 & ... & Feature data \\
 \hline
 \end{tabular}
@@ -268,10 +275,11 @@ Answer & 0 & 4 & Feature bit index \\
 \msgdef{SET_FEATURES}
 
 The set features message is used by the driver to configure the features of a
-device. The driver configures a number of bits at given index using one
-requets. The device provides in the answer the actual features value at the
-index after having configured the bits requested, giving an opportunity for the
-driver to detect if some of the bits it tried to set were not accepted.
+device. The driver configures one or several blocks of feature bits (one block
+is 32bits of feature) at a given block index one request. The device provides
+in the answer the actual features value at the index after having configured
+the bits requested, giving an opportunity for the driver to detect if some of
+the bits it tried to set were not accepted.
 
 The maximum number of feature bits that can be modified in one request depends
 on the maximum message size supported by both sides.
@@ -283,12 +291,12 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 4 & Feature bit index \\
-& 4 & 4 & Number of features \\
+Request & 0 & 4 & Feature block index \\
+& 4 & 4 & Number of feature blocks \\
 & 8 & ... & Feature data \\
 \hline
-Answer & 0 & 4 & Feature bit index \\
-& 4 & 4 & Number of features \\
+Answer & 0 & 4 & Feature block index \\
+& 4 & 4 & Number of feature blocks \\
 & 8 & ... & Feature data \\
 \hline
 \end{tabular}
@@ -544,6 +552,7 @@ principles:
 \item One Message Bus has one or more devices on the backend side handled by
       drivers on the frontend side.
 \item An endpoint can be connected to several Message Buses.
+\item Any Message bus must support to transmit messages of at least 44 bytes.
 \end{itemize}
 
 A Message Bus implementation must provide interfaces to transmit and receive
@@ -565,6 +574,14 @@ messages with the other side but could also provide solutions to:
         devices, one bus implementation could rely on a Device tree to get
         a list of devices available and generate the device info messages out
         of it instead of actually asking the device side using a message.
+    \item Adapt protocol and message size: when a driver is negociating with
+        a driver using the VIRTIO_MSG_VERSION, a bus can intercept the messages
+        to make sure that the version and size negociated is compatible with
+        what it can handle. This is for example modifying the size the driver
+        claims to support to reduce it to the maximum size it can support
+        and do the same with size claimed by the device. If a bus only support
+        specific version of the protocol it can also restrict what is claimed
+        by a driver or a device by modifying the message protocol version part.
 \end{itemize}
 
 While the bus implementation and how communication of the messages is done
@@ -676,8 +693,10 @@ expects an answer from the backend side.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 2 & Offset \\
+        & 2 & 2 & Number of device IDs requested \\
 \hline
 Answer & 0 & 2 & Offset \\
+       & 2 & 2 & Number of device IDs in the answer \\
        & 2 & 2 & Next offset or 0 if no devices after Offset \\
        & 4 & .. & Bit[n]: Device[offset + n] not available(0)/available(1) \\
 \hline

--- a/transport-msg.tex
+++ b/transport-msg.tex
@@ -74,27 +74,29 @@ Reserved                      & 0x0 & \\
 \hline
 VIRTIO_MSG_ERROR              & 0x1  & Any    \\
 \hline
-VIRTIO_MSG_GET_DEVICE_INFO    & 0x2  & Driver \\
+VIRTIO_MSG_VERSION            & 0x2  & Driver \\
 \hline
-VIRTIO_MSG_GET_FEATURES       & 0x3  & Driver \\
+VIRTIO_MSG_GET_DEVICE_INFO    & 0x3  & Driver \\
 \hline
-VIRTIO_MSG_SET_FEATURES       & 0x4  & Driver \\
+VIRTIO_MSG_GET_FEATURES       & 0x4  & Driver \\
 \hline
-VIRTIO_MSG_GET_CONFIG         & 0x5  & Driver \\
+VIRTIO_MSG_SET_FEATURES       & 0x5  & Driver \\
 \hline
-VIRTIO_MSG_SET_CONFIG         & 0x6  & Driver \\
+VIRTIO_MSG_GET_CONFIG         & 0x6  & Driver \\
 \hline
-VIRTIO_MSG_GET_CONFIG_GEN     & 0x7  & Driver \\
+VIRTIO_MSG_SET_CONFIG         & 0x7  & Driver \\
 \hline
-VIRTIO_MSG_GET_DEVICE_STATUS  & 0x8  & Driver \\
+VIRTIO_MSG_GET_CONFIG_GEN     & 0x8  & Driver \\
 \hline
-VIRTIO_MSG_SET_DEVICE_STATUS  & 0x9  & Driver \\
+VIRTIO_MSG_GET_DEVICE_STATUS  & 0x9  & Driver \\
 \hline
-VIRTIO_MSG_GET_VQUEUE         & 0xA  & Driver \\
+VIRTIO_MSG_SET_DEVICE_STATUS  & 0xA  & Driver \\
 \hline
-VIRTIO_MSG_SET_VQUEUE         & 0xB  & Driver \\
+VIRTIO_MSG_GET_VQUEUE         & 0xB  & Driver \\
 \hline
-VIRTIO_MSG_RESET_VQUEUE       & 0xC  & Driver \\
+VIRTIO_MSG_SET_VQUEUE         & 0xC  & Driver \\
+\hline
+VIRTIO_MSG_RESET_VQUEUE       & 0xD  & Driver \\
 \hline
 VIRTIO_MSG_EVENT_CONFIG       & 0x20 & Device \\
 \hline
@@ -134,6 +136,58 @@ Any     & 0 & 4 & Virtio Message Error Code \\
         & 4 & 1 & Message ID which generated an error or 0 if none \\
         & 5 & 1 & Data Type: 0 (Reserved), 1 (STRING), 2-255 (Implementation Defined) \\
         & 6 & 30 & Null Terminated String if Data Type is STRING else Implementation Defined \\
+\hline
+\end{tabular}
+
+\msgdef{VERSION}
+
+The version message is used by the driver to negociate the version of the
+Virtio Message protocol to use.
+
+This message is sent by the driver to the device and expects an answer from the
+device.
+
+The version message is not specific to a device so the device ID field of the
+message header must be set to 0.
+
+The current version of the protocol describe by this specification is:
+\emph{0.1}.
+
+A Virtio Message Protocol Version is encoded in 32 bits with:
+\begin{itemize}
+    \item Bits[31-16]: Major Version (Current is 0).
+    \item Bits[15-0]: Minor Version (Current is 1).
+\end{itemize}
+
+The version message must be sent by the driver before any other Virtio
+messages and the version is frozen once a message other than the version
+message is sent by the driver.
+
+To re-negociate a version, the Virtio Message Bus needs to be reseted through
+a Bus Implementation Defined way (for example using the BUS_MSG_STATUS Virtio
+Bus Message).
+
+The version negociation shall be done by the driver following those steps:
+\begin{itemize}
+    \item The driver sends a version message with the highest version of the
+        protocol its supports.
+    \item The device answers with the highest version lower or equals to the
+        version requested by the driver that it supports. If the device does
+        not support any lower version, it answers with an Error.
+    \item If the driver can work with the version answered, it continues
+        using it otherwise it can send an other version message to try to
+        negociate a different version.
+\end{itemize}
+
+\begin{tabular}{|l|l|l|l|}
+\hline
+Type & Offset & Size (bytes) & Content \\
+\hline \hline
+Request & 0 & 4 & Driver Protocol version \\
+& 4 & 32 & Reserved (MBZ) \\
+\hline
+Answer & 0 & 4 & Device Protocol version \\
+& 4 & 32 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 

--- a/transport-msg.tex
+++ b/transport-msg.tex
@@ -15,7 +15,8 @@ cross system communications required in an heterogeneous system configuration.
 
 The messages have the following properties:
 \begin{itemize}
-\item A message size is 40 bytes.
+\item A message has a minimum size of 8 bytes and any implementation must support
+  to transmit messages of up to 64 bytes.
 \item Most messages are driver/device initialization messages.
 \item Messages are expected to be sent at low frequencies and quick round-trip is
   not necessary and should not impact global performances (as communication
@@ -34,7 +35,9 @@ VIRTIO_MSG_ID & 1 & 1 & Message ID \\
 \hline
 VIRTIO_MSG_DEV_ID & 2 & 2 & Device ID, must be set to 0 if VIRTIO_MSG_TYPE Bit[1]=1\\
 \hline
-VIRTIO_MSG_PAYLOAD & 4 & 36 & Payload \\
+VIRTIO_MSG_SIZE & 4 & 2 & Message Payload Size\\
+\hline
+VIRTIO_MSG_PAYLOAD & 6 & ...  & Payload \\
 \hline
 \end{tabularx}
 
@@ -135,14 +138,15 @@ Type & Offset & Size (bytes) & Content \\
 Any     & 0 & 4 & Virtio Message Error Code \\
         & 4 & 1 & Message ID which generated an error or 0 if none \\
         & 5 & 1 & Data Type: 0 (Reserved), 1 (STRING), 2-255 (Implementation Defined) \\
-        & 6 & 30 & Null Terminated String if Data Type is STRING else Implementation Defined \\
+        & 6 & ... & Null Terminated String if Data Type is STRING else Implementation Defined \\
 \hline
 \end{tabular}
 
 \msgdef{VERSION}
 
 The version message is used by the driver to negociate the version of the
-Virtio Message protocol to use.
+Virtio Message protocol to use and inform the other side of the maximum message
+size it can handle (including the message header).
 
 This message is sent by the driver to the device and expects an answer from the
 device.
@@ -184,10 +188,10 @@ The version negociation shall be done by the driver following those steps:
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Driver Protocol version \\
-& 4 & 32 & Reserved (MBZ) \\
+& 4 & 4 & Maximum message size supported \\
 \hline
 Answer & 0 & 4 & Device Protocol version \\
-& 4 & 32 & Reserved (MBZ) \\
+& 4 & 4 & Maximum message size supported \\
 \hline
 \end{tabular}
 
@@ -203,24 +207,30 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 36 & Reserved (MBZ) \\
+Request & 0 & 0 & None \\
 \hline
 Answer & 0 & 4 & Device version \\
 & 4 & 4 & Device ID \\
 & 8 & 4 & Vendor ID \\
-& 12 & 24 & Reserved (MBZ) \\
+& 12 & 4 & Number of feature bits \\
+& 16 & 4 & Configuration size in bytes \\
 \hline
 \end{tabular}
 
 \msgdef{GET_FEATURES}
 
-The get features message is used to retrieve 256 bits of feature information
-from the device. The driver requests features at an index and the device answers
-with the features bits at 256*index.
+The get features message is used to retrieve a number of bits of feature
+information from the device. The driver requests features at an index (in bits)
+and a number of bits and the device answers with the features bits at the
+wanted index.
+
+The maximum number of feature bits that can be requested in one message depends
+on the maximum message size supported by both sides.
 
 If there are no features available at the requested index but there are
 features available after the index, the backend must return an all-zero
 response.
+
 If there are no features available at and after the requested index, the
 backend must return an ERROR message to inform the frontend that it does not
 need to scan features further.
@@ -232,21 +242,25 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 4 & Feature index \\
-& 4 & 32 & Reserved (MBZ) \\
+Request & 0 & 4 & Feature bit index \\
+& 4 & 4 & Number of features \\
 \hline
-Answer & 0 & 4 & Feature index \\
-& 4 & 32 & Feature data \\
+Answer & 0 & 4 & Feature bit index \\
+& 4 & 4 & Number of features \\
+& 8 & ... & Feature data \\
 \hline
 \end{tabular}
 
 \msgdef{SET_FEATURES}
 
 The set features message is used by the driver to configure the features of a
-device. The driver configures 256 bits a time a given index. The device
-provides in the answer the actual features value at the index after having
-configured the bit requested giving an opportunity for the driver to detect if
-some of the bits it tried to set were not accepted.
+device. The driver configures a number of bits at given index using one
+requets. The device provides in the answer the actual features value at the
+index after having configured the bits requested, giving an opportunity for the
+driver to detect if some of the bits it tried to set were not accepted.
+
+The maximum number of feature bits that can be modified in one request depends
+on the maximum message size supported by both sides.
 
 This message is sent by the driver to the device and expects an answer from the
 device.
@@ -255,19 +269,23 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 4 & Feature index \\
-& 4 & 32 & Feature data \\
+Request & 0 & 4 & Feature bit index \\
+& 4 & 4 & Number of features \\
+& 8 & ... & Feature data \\
 \hline
-Answer & 0 & 4 & Feature index \\
-& 4 & 32 & Feature data \\
+Answer & 0 & 4 & Feature bit index \\
+& 4 & 4 & Number of features \\
+& 8 & ... & Feature data \\
 \hline
 \end{tabular}
 
 \msgdef{GET_CONFIG}
 
 The get configuration message is used by the driver to retrieve a part of the
-configuration values of the device. The driver can request up to 256 bits at
-a given offset in the device configuration space.
+configuration values of the device at a given offset.
+
+The maximum size of configuration that can be requested in one message depends
+on the maximum message size supported by both sides.
 
 This message is sent by the driver to the device and expects an answer from the
 device.
@@ -276,23 +294,26 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 3 & Configuration offset \\
-& 3 & 1 & Number of bytes (1-32) \\
-& 4 & 32 & Reserved (MBZ) \\
+Request & 0 & 4 & Configuration offset in bytes \\
+& 4 & 4 & Number of bytes \\
 \hline
-Answer & 0 & 3 & Configuration offset \\
-& 3 & 1 & Number of bytes (1-32) \\
-& 4 & 32 & Configuration data \\
+Answer & 0 & 4 & Configuration offset in bytes \\
+& 4 & 4 & Number of bytes \\
+& 8 & ... & Configuration data \\
 \hline
 \end{tabular}
 
 \msgdef{SET_CONFIG}
 
 The set configuration message is used by the driver to modify a part of the
-configuration values of the device. The driver can modify up to 256 bits at a
-given offset in the device configuration. The device answers with the actual
-configuration value at the offset after the modification to give a chance to the
-driver to detect changes that have not been accepted by the device.
+configuration values of the device.
+
+The maximum size of configuration that can be modified in one request depends
+on the maximum message size supported by both sides.
+
+The device answers with the actual configuration value at the offset after the
+modification to give a chance to the driver a chance to detect changes that
+have not been accepted by the device.
 
 This message is sent by the driver to the device and expects an answer from the
 device.
@@ -301,13 +322,13 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 3 & Configuration offset \\
-& 3 & 1 & Number of bytes (1-32) \\
-& 4 & 32 & Configuration data \\
+Request & 0 & 4 & Configuration offset in bytes\\
+& 4 & 4 & Number of bytes \\
+& 8 & ... & Configuration data \\
 \hline
-Answer & 0 & 3 & Configuration offset \\
-& 3 & 1 & Number of bytes (1-32) \\
-& 4 & 32 & Configuration data \\
+Answer & 0 & 3 & Configuration offset in bytes\\
+& 4 & 4 & Number of bytes \\
+& 8 & ... & Configuration data \\
 \hline
 \end{tabular}
 
@@ -325,10 +346,9 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 36 & Reserved (MBZ) \\
+Request & 0 & 0 & None \\
 \hline
 Answer & 0 & 4 & Atomicity value \\
-& 4 & 32 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 
@@ -344,10 +364,9 @@ device.
 \hline
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
-Request & 0 & 36 & Reserved (MBZ) \\
+Request & 0 & 0 & None \\
 \hline
 Answer & 0 & 4 & Device status \\
-& 4 & 32 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 
@@ -364,9 +383,8 @@ device.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Device status \\
-& 4 & 32 & Reserved (MBZ) \\
 \hline
-Answer & 0 & 36 & Reserved (MBZ) \\
+Answer & 0 & 0 & None \\
 \hline
 \end{tabular}
 
@@ -384,7 +402,6 @@ device.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Virtqueue index \\
-& 4 & 32 & Reserved (MBZ) \\
 \hline
 Answer & 0 & 4 & Virtqueue index \\
 & 4 & 4 & Max virtqueue size \\
@@ -438,9 +455,8 @@ device.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Virtqueue index \\
-& 4 & 32 & Reserved (MBZ) \\
 \hline
-Answer & 0 & 36 & Reserved (MBZ) \\
+Answer & 0 & 0 & None \\
 \hline
 \end{tabular}
 
@@ -453,6 +469,9 @@ answer) and optionally the part of the configuration that has been modified. If
 this is not provided, the driver will have to use the GET\_CONFIG to retrieve
 the configuration and discover what has changed.
 
+The maximum size of data that can be communicated with an event depends on the
+maximum message size supported by both sides.
+
 This message is sent by the device to the driver and does not expect any
 answer.
 
@@ -461,10 +480,9 @@ answer.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Device status \\
-& 4 & 3 & Configuration offset \\
-& 7 & 1 & Number of bytes (1-16) \\
-& 8 & 16 & Configuration data \\
-& 24 & 12 & Reserved (MBZ) \\
+& 4 & 4 & Configuration offset \\
+& 8 & 4 & Number of bytes \\
+& 12 & ... & Configuration data \\
 \hline
 \end{tabular}
 
@@ -485,7 +503,6 @@ Type & Offset & Size (bytes) & Content \\
 Request & 0 & 4 & Virtqueue index \\
 & 4 & 4 & Next offset \\
 & 8 & 4 & Next wrap \\
-& 12 & 24 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 
@@ -502,7 +519,6 @@ answer.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Virtqueue index \\
-& 4 & 32 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 
@@ -604,11 +620,14 @@ send as answer to an other message or directly to signal an error.
 The Get Devices message is used by the frontend to retrieve the IDs of the
 devices available on the backend of the bus.
 
-The frontend requests the availability of a group of 256 device IDs and the
+The frontend requests the availability of a group of device IDs and the
 backend returns a bitmap indicating which device IDs are available at the
 requested device ID offset.
 
-A request at offset X gives the availability of device IDs X*256 to (X+1)*256-1.
+A request at offset X gives the availability of device IDs starting at X with
+a number of IDs depending on the actual message size received:
+
+X to (X + Message Size)*8 - 1
 
 The backend also returns a next offset indicating to the frontend what device
 ID offset should be requested next. This is to reduce the number of messages
@@ -617,7 +636,7 @@ required to scan all IDs when the backend has device IDs far from each other.
 This message shall be used in the following way:
 \begin{itemize}
 \item frontend request device IDs at offset X.
-\item backend answers with the availability of device IDs X*256 to (X+1)*256-1
+\item backend answers with the availability of device IDs X to X + Y
   and indicates to the frontend which offset to request after using the next
   offset.
 \end{itemize}
@@ -633,11 +652,10 @@ expects an answer from the backend side.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 2 & Offset \\
-        & 2 & 36 & Reserved (MBZ) \\
 \hline
 Answer & 0 & 2 & Offset \\
        & 2 & 2 & Next offset or 0 if no devices after Offset \\
-       & 4 & 32 & Bit[n]: Device[offset*256 + n] not available(0)/available(1) \\
+       & 4 & .. & Bit[n]: Device[offset + n] not available(0)/available(1) \\
 \hline
 \end{tabular}
 
@@ -653,7 +671,6 @@ This message is sent by the backend of the bus and does not expect any answer.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 2 & Device ID \\
-        & 2 & 34 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 
@@ -669,7 +686,6 @@ This message is sent by the backend of the bus and does not expect any answer.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 2 & Device ID \\
-        & 2 & 34 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 
@@ -689,10 +705,8 @@ back by the receiver in its answer.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Data \\
-        & 4 & 32 & Reserved (MBZ) \\
 \hline
 Answer & 0 & 4 & Request Data \\
-       & 4 & 32 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 
@@ -728,7 +742,6 @@ does not expect any answer.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 1 & New state \\
-        & 1 & 35 & Reserved (MBZ) \\
 \hline
 \end{tabular}
 

--- a/transport-msg.tex
+++ b/transport-msg.tex
@@ -170,25 +170,21 @@ size it can handle (including the message header).
 This message is sent by the driver to the device and expects an answer from the
 device.
 
-The version message is not specific to a device so the device ID field of the
-message header must be set to 0.
+The protocol version is an unsigned integer increased each time the
+specification changes and must be negociated for each device.
 
 The current version of the protocol describe by this specification is:
-\emph{0.1}.
-
-A Virtio Message Protocol Version is encoded in 32 bits with:
-\begin{itemize}
-    \item Bits[31-16]: Major Version (Current is 0).
-    \item Bits[15-0]: Minor Version (Current is 1).
-\end{itemize}
+\emph{1}.
 
 The version message must be sent by the driver before any other Virtio
 messages and the version is frozen once a message other than the version
-message is sent by the driver.
+message is sent by the driver. Once the version is frozen, any version message
+with a size or version different from what was negociated must be answered with
+an ERROR message by the device.
 
-To re-negociate a version, the Virtio Message Bus needs to be reseted through
-a Bus Implementation Defined way (for example using the BUS_MSG_STATUS Virtio
-Bus Message).
+To re-negociate a protocol version, the device needs to be reseted using the
+SET_DEVICE_STATUS or any other Bus specific reset solution to allow
+renogociating the version or message size.
 
 The version negociation shall be done by the driver following those steps:
 \begin{itemize}
@@ -228,11 +224,10 @@ Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 0 & None \\
 \hline
-Answer & 0 & 4 & Device version \\
-& 4 & 4 & Device ID \\
-& 8 & 4 & Vendor ID \\
-& 12 & 4 & Number of feature bits \\
-& 16 & 4 & Configuration size in bytes \\
+Answer & 0 & 4 & Device ID \\
+& 4 & 4 & Vendor ID \\
+& 8 & 4 & Number of feature bits \\
+& 12 & 4 & Configuration size in bytes \\
 \hline
 \end{tabular}
 

--- a/transport-msg.tex
+++ b/transport-msg.tex
@@ -552,12 +552,31 @@ principles:
 \end{itemize}
 
 A Message Bus implementation must provide interfaces to transmit and receive
-messages with the other side.
+messages with the other side but could also provide solutions to:
+\begin{itemize}
+    \item Handle memory sharing: it can be informed by drivers when they need
+        some memory to be accessible to devices and use some custom messages
+        or solutions to make the memory accessible and inform the device side
+        that some memory is now available. This can be useful in a VM to VM
+        use case on top of an hypervisor to request the hypervisor to make some
+        of the driver memory accessible into the VM hosting the device.
+    \item Out of band notifications: transfering messages to signal events
+        could not be the best solution in all cases. The bus implementation
+        could for example have a solution to use one MSI-X per virtqueue and
+        create the event message for the transport when it triggers instead
+        of actually transferring an even message between the device and the
+        driver.
+    \item Full static discovery: instead of transfering messages to detect
+        devices, one bus implementation could rely on a Device tree to get
+        a list of devices available and generate the device info messages out
+        of it instead of actually asking the device side using a message.
+\end{itemize}
 
 While the bus implementation and how communication of the messages is done
 between the devices and the drivers is completely out of the scope of the
 specification, this chapter provides a set of Bus messages to help
 standardizing as much as possible a part of the bus implementation.
+
 
 \subsubsection{Discovery}\label{sec:Virtio Transport Options / Virtio Over Messages / Message Bus / Discovery}
 

--- a/transport-msg.tex
+++ b/transport-msg.tex
@@ -83,7 +83,9 @@ currently has.
 
 This system allows the driver to maintain a cache of the configuration space
 of a device and return values from it instead of asking the device when a
-configuration value is needed.
+configuration value is needed. The device will signal to the driver any change
+in the configuration that was not requested by the driver through the
+VIRTIO_MSG_EVENT_CONFIG event.
 
 \subsection{Messages Definition}\label{sec:Virtio Transport Options / Virtio Over Messages / Messages Definition}
 

--- a/transport-msg.tex
+++ b/transport-msg.tex
@@ -62,6 +62,27 @@ Error Code & Name & Description \\
 \hline
 \end{tabular}
 
+\subsection{Configuration Generation Count}\label{sec::Virtio Transport Options / Virtio Over Messages / Configuration Generation Count}
+
+To allow the driver to cache the configuration and prevent sending messages to
+access the configuration when it did not change, the Virtio Message Transport
+is using a \emph{Configuration generation count} value.
+
+The \emph{Configuration generation count} is a counter that is incremented by
+the device every time a value is modified in the configuration. It is
+communicated to the driver through an event (VIRTIO_MSG_EVENT_CONFIG) each time
+a configuration value is modified by the device itself and in the response to
+any modification of the configuration by the driver (through the
+VIRTIO_MSG_SET_CONFIG message).
+
+When the driver wants to modify a part of the configuration values, it has to
+provide the current value of the \emph{Configuration generation count} and the
+device will reject the request if the value provided is not the one it
+currently has.
+
+This system allows the driver to maintain a cache of the configuration space
+of a device and return values from it instead of asking the device when a
+configuration value is needed.
 
 \subsection{Messages Definition}\label{sec:Virtio Transport Options / Virtio Over Messages / Messages Definition}
 
@@ -89,17 +110,15 @@ VIRTIO_MSG_GET_CONFIG         & 0x6  & Driver \\
 \hline
 VIRTIO_MSG_SET_CONFIG         & 0x7  & Driver \\
 \hline
-VIRTIO_MSG_GET_CONFIG_GEN     & 0x8  & Driver \\
+VIRTIO_MSG_GET_DEVICE_STATUS  & 0x8  & Driver \\
 \hline
-VIRTIO_MSG_GET_DEVICE_STATUS  & 0x9  & Driver \\
+VIRTIO_MSG_SET_DEVICE_STATUS  & 0x9  & Driver \\
 \hline
-VIRTIO_MSG_SET_DEVICE_STATUS  & 0xA  & Driver \\
+VIRTIO_MSG_GET_VQUEUE         & 0xA  & Driver \\
 \hline
-VIRTIO_MSG_GET_VQUEUE         & 0xB  & Driver \\
+VIRTIO_MSG_SET_VQUEUE         & 0xB  & Driver \\
 \hline
-VIRTIO_MSG_SET_VQUEUE         & 0xC  & Driver \\
-\hline
-VIRTIO_MSG_RESET_VQUEUE       & 0xD  & Driver \\
+VIRTIO_MSG_RESET_VQUEUE       & 0xC  & Driver \\
 \hline
 VIRTIO_MSG_EVENT_CONFIG       & 0x20 & Device \\
 \hline
@@ -282,7 +301,8 @@ Answer & 0 & 4 & Feature bit index \\
 \msgdef{GET_CONFIG}
 
 The get configuration message is used by the driver to retrieve a part of the
-configuration values of the device at a given offset.
+configuration values of the device at a given offset together with the current
+value of the configuration generation count.
 
 The maximum size of configuration that can be requested in one message depends
 on the maximum message size supported by both sides.
@@ -299,7 +319,8 @@ Request & 0 & 4 & Configuration offset in bytes \\
 \hline
 Answer & 0 & 4 & Configuration offset in bytes \\
 & 4 & 4 & Number of bytes \\
-& 8 & ... & Configuration data \\
+& 8 & 4 & Configuration generation count \\
+& 12 & ... & Configuration data \\
 \hline
 \end{tabular}
 
@@ -307,6 +328,11 @@ Answer & 0 & 4 & Configuration offset in bytes \\
 
 The set configuration message is used by the driver to modify a part of the
 configuration values of the device.
+
+The driver must give the current value of the Configuration Generation Count
+and the device will reject the request with an error if its current Generation
+count value is different from the one it finds in the request. The new value
+of the Generation count is provided by the device in the answer.
 
 The maximum size of configuration that can be modified in one request depends
 on the maximum message size supported by both sides.
@@ -324,31 +350,13 @@ Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Configuration offset in bytes\\
 & 4 & 4 & Number of bytes \\
-& 8 & ... & Configuration data \\
+& 8 & 4 & Configuration generation count \\
+& 12 & ... & Configuration data \\
 \hline
 Answer & 0 & 3 & Configuration offset in bytes\\
 & 4 & 4 & Number of bytes \\
-& 8 & ... & Configuration data \\
-\hline
-\end{tabular}
-
-\msgdef{GET_CONFIG_GEN}
-
-The get configuration generation message is used by the driver to retrieve the
-device configuration atomicity value.
-
-TODO: need help to have a complete description here.
-
-This message is sent by the driver to the device and expects an answer from the
-device.
-
-\begin{tabular}{|l|l|l|l|}
-\hline
-Type & Offset & Size (bytes) & Content \\
-\hline \hline
-Request & 0 & 0 & None \\
-\hline
-Answer & 0 & 4 & Atomicity value \\
+& 8 & 4 & Configuration generation count \\
+& 12 & ... & Configuration data \\
 \hline
 \end{tabular}
 
@@ -465,9 +473,10 @@ Answer & 0 & 0 & None \\
 The event config message is sent by the device to signal to the driver that one
 or several values in the device configuration have changed. The message
 contains the current device status (as encoded in the GET\_DEVICE\_STATUS
-answer) and optionally the part of the configuration that has been modified. If
-this is not provided, the driver will have to use the GET\_CONFIG to retrieve
-the configuration and discover what has changed.
+answer), the new Configuration Generation Count value and optionally the part
+of the configuration that has been modified. If this is not provided, the
+driver will have to use the GET\_CONFIG to retrieve the configuration and
+discover what has changed.
 
 The maximum size of data that can be communicated with an event depends on the
 maximum message size supported by both sides.
@@ -480,9 +489,10 @@ answer.
 Type & Offset & Size (bytes) & Content \\
 \hline \hline
 Request & 0 & 4 & Device status \\
-& 4 & 4 & Configuration offset \\
-& 8 & 4 & Number of bytes \\
-& 12 & ... & Configuration data \\
+& 4 & 4 & Configuration generation count \\
+& 8 & 4 & Configuration offset \\
+& 12 & 4 & Number of bytes \\
+& 16 & ... & Configuration data \\
 \hline
 \end{tabular}
 


### PR DESCRIPTION
Introduce the VIRTIO_MSG_VERSION and define a protocol to negociate a protocol version between the driver and the device side.

Current version is set to 0.1.

Bump all message number so that the Version message is numbered 0x2 (0x1 being the Error message).

# Thanks for proposing a change to the virtio-msg specification

This is not the same as proposing a change to the VirtIO spec. This
repository is intended for preparing the virtio-msg transport
specification before it's submission to the VIRTIO TC.

If your intention was to suggestion to change to the upstream please
propose the change as a patch to the [mailing list](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=virtio#feedback).
