### PR TITLE
github: give tag and pdf names unique to owner fork and branch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: virio-msg-draft-v${{ github.run_number }} # Or a more meaningful tag
+          tag_name: ${{github.ref_name}}-${{ github.repository_owner }}-draft-v${{ github.run_number }}
           release_name: Draft ${{ github.run_number }}
           draft: false
           prerelease: false
@@ -33,5 +33,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: virtio-v1.4-wd01.pdf
-          asset_name: virtio-v1.4-wd01.pdf
+          asset_name: ${{github.ref_name}}-${{ github.repository_owner }}-draft-v${{ github.run_number }}.pdf
           asset_content_type: application/pdf


### PR DESCRIPTION
The job number is not unique for different forks and this causes issues with the tags which are global. Use the repo owners github name in the tag and the branch as well.  Still include the job number to make unique.

Also change the pdf file name so we know where it came from.
